### PR TITLE
fix: save package in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "license": "MIT",
   "builders": "./builders.json",
   "schematics": "./collection.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "scripts": {
     "dev": "now dev",
     "build": "tsc",


### PR DESCRIPTION
In the latest versions of the CLI `ng-add` packages can be added to `devDependencies` and this package is perfect for such use case since it's only needed for development.

See: https://github.com/angular/angular-cli/pull/15815